### PR TITLE
Add scriptCode locale option

### DIFF
--- a/lib/src/helpers/locale_utils.dart
+++ b/lib/src/helpers/locale_utils.dart
@@ -5,9 +5,27 @@ String getLocale(
   BuildContext context, {
   Locale? selectedLocale,
 }) {
-  if (selectedLocale != null) {
-    return '${selectedLocale.languageCode}_${selectedLocale.countryCode}';
+  // Function to create the locale string, including scriptCode if available
+  String createLocaleString(Locale locale) {
+    final languageCode = locale.languageCode;
+    final scriptCode = locale.scriptCode ?? ''; // Default to empty if scriptCode is null
+    final countryCode = locale.countryCode ?? ''; // Default to empty if countryCode is null
+
+    if (scriptCode.isNotEmpty && countryCode.isNotEmpty) {
+      return '${languageCode}_${scriptCode}_${countryCode}';
+    } else if (scriptCode.isNotEmpty) {
+      return '${languageCode}_${scriptCode}';
+    } else if (countryCode.isNotEmpty) {
+      return '${languageCode}_${countryCode}';
+    } else {
+      return languageCode;
+    }
   }
+
+  if (selectedLocale != null) {
+    return createLocaleString(selectedLocale);
+  }
+
   final Locale locale = Localizations.localeOf(context);
-  return '${locale.languageCode}_${locale.countryCode}';
+  return createLocaleString(locale);
 }


### PR DESCRIPTION
Hello,

I added the possibility for the scriptCode in locale_utils.

My problem was that in the project we use Locale.fromSubtags(languageCode: 'sr', scriptCode: 'Latn') for Serbian language in the Latin alphabet, but with the current implementation, the Cyrillic alphabet was shown in the dialog.

This PR fixes this issue.