### PR TITLE
Fix/accessibility labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.7.2 - 2026-02-26
+- Added semantics support (`previousButtonSemanticsLabel`, `nextButtonSemanticsLabel`) to header navigation arrows via `PickerHeaderSettings`.
+
 ## 6.7.1 - 2026-01-19
 - Added operation order fix from [Jerrywell](https://github.com/jerrywellcake) fork.
 

--- a/lib/src/helpers/settings/header_settings.dart
+++ b/lib/src/helpers/settings/header_settings.dart
@@ -16,6 +16,8 @@ class PickerHeaderSettings {
     this.headerPadding = const EdgeInsets.all(16.0),
     this.arrowAlpha = 0.5,
     this.headerAlignment = CrossAxisAlignment.start,
+    this.previousButtonSemanticsLabel,
+    this.nextButtonSemanticsLabel,
   });
 
   /// Hides the row with the arrows + years/months page range from the header, forcing the user to scroll to change the page.
@@ -84,6 +86,16 @@ class PickerHeaderSettings {
   ///
   /// default: `CrossAxisAlignment.start`
   final CrossAxisAlignment headerAlignment;
+
+  /// The semantics label of the previous button.
+  ///
+  /// default: `null`
+  final String? previousButtonSemanticsLabel;
+
+  /// The semantics label of the next button.
+  ///
+  /// default: `null`
+  final String? nextButtonSemanticsLabel;
 
   PickerHeaderSettings copyWith({
     bool? hideHeaderRow,

--- a/lib/src/month_picker_widgets/header/header_arrows.dart
+++ b/lib/src/month_picker_widgets/header/header_arrows.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 ///The arrows that are used on the header to change between the pages of the grid.
@@ -14,6 +16,8 @@ class HeaderArrows extends StatelessWidget {
     this.nextIcon,
     required this.arrowAlpha,
     required this.verticalScrolling,
+    this.previousButtonSemanticsLabel,
+    this.nextButtonSemanticsLabel,
   });
   final Color? arrowcolors;
   final double? arrowSize;
@@ -23,37 +27,47 @@ class HeaderArrows extends StatelessWidget {
   final IconData? previousIcon;
   final IconData? nextIcon;
   final bool verticalScrolling;
+  final String? previousButtonSemanticsLabel;
+  final String? nextButtonSemanticsLabel;
 
   @override
   Widget build(BuildContext context) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        IconButton(
-          icon: Icon(
-            previousIcon ??
-                (verticalScrolling
-                    ? Icons.keyboard_arrow_up
-                    : Icons.keyboard_arrow_left),
-            color: upState
-                ? arrowcolors
-                : arrowcolors!.withValues(alpha: arrowAlpha),
-            size: arrowSize,
+        Semantics(
+          label: previousButtonSemanticsLabel,
+          role: SemanticsRole.spinButton,
+          child: IconButton(
+            icon: Icon(
+              previousIcon ??
+                  (verticalScrolling
+                      ? Icons.keyboard_arrow_up
+                      : Icons.keyboard_arrow_left),
+              color: upState
+                  ? arrowcolors
+                  : arrowcolors!.withValues(alpha: arrowAlpha),
+              size: arrowSize,
+            ),
+            onPressed: upState ? onUpButtonPressed : null,
           ),
-          onPressed: upState ? onUpButtonPressed : null,
         ),
-        IconButton(
-          icon: Icon(
-            nextIcon ??
-                (verticalScrolling
-                    ? Icons.keyboard_arrow_down
-                    : Icons.keyboard_arrow_right),
-            color: downState
-                ? arrowcolors
-                : arrowcolors!.withValues(alpha: arrowAlpha),
-            size: arrowSize,
+        Semantics(
+          label: nextButtonSemanticsLabel,
+          role: SemanticsRole.spinButton,
+          child: IconButton(
+            icon: Icon(
+              nextIcon ??
+                  (verticalScrolling
+                      ? Icons.keyboard_arrow_down
+                      : Icons.keyboard_arrow_right),
+              color: downState
+                  ? arrowcolors
+                  : arrowcolors!.withValues(alpha: arrowAlpha),
+              size: arrowSize,
+            ),
+            onPressed: downState ? onDownButtonPressed : null,
           ),
-          onPressed: downState ? onDownButtonPressed : null,
         ),
       ],
     );

--- a/lib/src/month_picker_widgets/header/header_arrows.dart
+++ b/lib/src/month_picker_widgets/header/header_arrows.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 
 ///The arrows that are used on the header to change between the pages of the grid.
@@ -36,8 +34,10 @@ class HeaderArrows extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         Semantics(
-          label: previousButtonSemanticsLabel,
-          role: SemanticsRole.spinButton,
+          label: previousButtonSemanticsLabel ??
+              MaterialLocalizations.of(context).previousMonthTooltip,
+          button: true,
+          excludeSemantics: true,
           child: IconButton(
             icon: Icon(
               previousIcon ??
@@ -53,8 +53,10 @@ class HeaderArrows extends StatelessWidget {
           ),
         ),
         Semantics(
-          label: nextButtonSemanticsLabel,
-          role: SemanticsRole.spinButton,
+          label: nextButtonSemanticsLabel ??
+              MaterialLocalizations.of(context).nextMonthTooltip,
+          button: true,
+          excludeSemantics: true,
           child: IconButton(
             icon: Icon(
               nextIcon ??

--- a/lib/src/month_picker_widgets/header/header_row.dart
+++ b/lib/src/month_picker_widgets/header/header_row.dart
@@ -79,6 +79,12 @@ class HeaderRow extends StatelessWidget {
                     .monthPickerDialogSettings.headerSettings.arrowAlpha,
                 verticalScrolling: controller
                     .monthPickerDialogSettings.dialogSettings.verticalScrolling,
+                previousButtonSemanticsLabel: controller
+                    .monthPickerDialogSettings
+                    .headerSettings
+                    .previousButtonSemanticsLabel,
+                nextButtonSemanticsLabel: controller.monthPickerDialogSettings
+                    .headerSettings.nextButtonSemanticsLabel,
               ),
           ]
         : <Widget>[

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: month_picker_dialog
 description: Internationalized dialog for picking a single month from an infinite list of years.
-version: 6.7.1
+version: 6.7.2
 homepage: https://github.com/Macacoazul01/month_picker_dialog
 
 environment:


### PR DESCRIPTION
Add semantics support for header navigation arrows

This PR adds accessibility support to the header navigation arrows by introducing two new optional parameters in PickerHeaderSettings:
previousButtonSemanticsLabel — semantic label for the "previous" arrow button
nextButtonSemanticsLabel — semantic label for the "next" arrow button\
These labels are passed down to a Semantics widget wrapping each IconButton in HeaderArrows, with button: true and excludeSemantics: true to ensure screen readers announce the custom label instead of the default "icon" description.

Motivation

Without explicit semantics, screen readers (e.g. TalkBack, VoiceOver) would announce the arrows as "icon", providing no meaningful context to visually impaired users. With this change, developers can provide localized, descriptive labels for these controls.
Usage
```
MonthPickerDialogSettings(
  headerSettings: PickerHeaderSettings(
    previousButtonSemanticsLabel: 'Previous month',
    nextButtonSemanticsLabel: 'Next month',
  ),
)
```